### PR TITLE
docs: clarify USBs are vertical, through hole mount

### DIFF
--- a/pcbs/dreamebreakout/Readme.md
+++ b/pcbs/dreamebreakout/Readme.md
@@ -20,9 +20,9 @@ All the parts required should be available on Aliexpress or similar
 
 - 1x 2.00mm pitch 2x8P male header
 - 2x 2.54mm pitch 1x8P female header
-- 1x 6x6mm tactile button
-- 1x micro usb port
-- 1x usb a port
+- 1x 6x6mm tactile button 
+- 1x Micro USB Receptacle, Type B, Through-Hole, Vertical ([example](https://www.mouser.com/ProductDetail/GCT/USB3131-30-0230-A?qs=KUoIvG/9IlYmRfH6E2AKbw==))
+- 1x USB Connectors USB 2.0, Type A, Receptacle, Vertical, 4 Pins ([example](https://www.mouser.com/ProductDetail/Amphenol-Commercial-Products/GSB11111ALF?qs=%2BRAvXJslkuBFR1fwnWS5IA==))
 
 Optional (can also be done via a regular jumper wire using the larger headers):
 - 2x 2.00mm pitch 1x2P male header


### PR DESCRIPTION
> Feel free to make any edit to the PR as required

## Summary

Provide additional clarification for the type of USB compatible with the PCB with example.
- 1x Micro USB Receptacle, Type B, Through Hole, Vertical, ~~With Through Hole Shell Stakes~~ ~~([example](https://www.mouser.com/ProductDetail/GCT/USB3145-30-1-A?qs=KUoIvG/9IlYD1lvSRu5iyg==))~~ ([example](https://www.mouser.com/ProductDetail/GCT/USB3131-30-0230-A?qs=KUoIvG/9IlYmRfH6E2AKbw==))
- 1x USB Connectors USB 2.0, Type A, Receptacle, Vertical, 4 Pins ([example](https://www.mouser.com/ProductDetail/Amphenol-Commercial-Products/GSB11111ALF?qs=%2BRAvXJslkuBFR1fwnWS5IA==))


The example provided has dataset and 3D view of the component to provide better reference for the parts.

## Motivation

Some of the shops / online store often sell horizontal mount type ([example from aliexpress when searched for "usb a connector"](https://www.aliexpress.com/item/32769985312.html)). These are not immediately compatible with the PCB.

This is what I've incorrectly purchased earlier :) 

![261813136-39c10988-c39e-44f8-ac2d-ae7be2d4827e](https://github.com/Hypfer/valetudo-dreameadapter/assets/8733840/81ab490d-7335-4bfa-a453-8faf5b6512c4)

